### PR TITLE
Pga 31/movement screen props

### DIFF
--- a/app/src/Components/ExerciseCardComp.tsx
+++ b/app/src/Components/ExerciseCardComp.tsx
@@ -6,14 +6,14 @@ import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 
 // You can define and add ExerciseCard for each movement inside MovementScreen() (Movements.tsx) as follow:
 // <ExerciseCard imageAddr={require('../../assets/pic1.jpeg')} name='Diaphragm Breathe' screenName="MovementInfo" />
-const ExerciseCard = (props: { screenName: any; imageAddr: string; name: string; }) => {
+const ExerciseCard = (props: { screenName: any; imageAddr: string; name: string; data: any}) => {
   const navigation = useNavigation<NativeStackNavigationProp>();
   return (
     <View>
       <Pressable
         style={styles.cardPressable}
         //We need to add screens for each movement which would contain muscle map
-        onPress={() => navigation.navigate(props.screenName)}
+        onPress={() => navigation.navigate(props.screenName, {props})}
       >
         <Image
           style={styles.rectangleIcon}

--- a/app/src/screens/Homepage.tsx
+++ b/app/src/screens/Homepage.tsx
@@ -10,7 +10,6 @@ import { NavigationContainer } from '@react-navigation/native';
 const HomeTab = createMaterialTopTabNavigator();
 const Stack = createNativeStackNavigator();
 
-//TODO, update navigation.
 function Root() {
     return (
         <HomeTab.Navigator>
@@ -23,17 +22,17 @@ function Root() {
 const Homepage = () => {
     
     return (
-            // <HomeTab.Navigator>
-            //     <HomeTab.Screen name="Movements" component={MovementScreen}/>
-            //     <HomeTab.Screen name="Weekly Tips" component={WeeklyTipsScreen}/>
-            // </HomeTab.Navigator>
             <NavigationContainer independent={true}>
                 <Stack.Navigator screenOptions={{ headerShown: false }}>
                     <Stack.Screen
                         name="Root"
                         component={Root}
                     />
-                    <Stack.Screen name="MovementInfo" component={MovementInfo} options={{headerShown: true, headerTitle: "Movement", headerTitleAlign: 'center'}}/>
+                    <Stack.Screen 
+                        name="MovementInfo"
+                        component={MovementInfo}
+                        options={{headerShown: true, headerTitle: "Movement", headerTitleAlign: 'center'}}
+                    />
                 </Stack.Navigator>
             </NavigationContainer>
             );

--- a/app/src/screens/Homepage.tsx
+++ b/app/src/screens/Homepage.tsx
@@ -3,19 +3,41 @@ import React from "react";
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs'
 import MovementScreen from "./Movements";
 import WeeklyTipsScreen from "./WeeklyTips";
+import MovementInfo from "./MovementInfo";
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { NavigationContainer } from '@react-navigation/native';
 
 const HomeTab = createMaterialTopTabNavigator();
+const Stack = createNativeStackNavigator();
 
-const Homepage = () => {
-
+//TODO, update navigation.
+function Root() {
     return (
         <HomeTab.Navigator>
             <HomeTab.Screen name="Movements" component={MovementScreen}/>
             <HomeTab.Screen name="Weekly Tips" component={WeeklyTipsScreen}/>
         </HomeTab.Navigator>
     );
-
 }
+
+const Homepage = () => {
+    
+    return (
+            // <HomeTab.Navigator>
+            //     <HomeTab.Screen name="Movements" component={MovementScreen}/>
+            //     <HomeTab.Screen name="Weekly Tips" component={WeeklyTipsScreen}/>
+            // </HomeTab.Navigator>
+            <NavigationContainer independent={true}>
+                <Stack.Navigator screenOptions={{ headerShown: false }}>
+                    <Stack.Screen
+                        name="Root"
+                        component={Root}
+                    />
+                    <Stack.Screen name="MovementInfo" component={MovementInfo} options={{headerShown: true, headerTitle: "Movement", headerTitleAlign: 'center'}}/>
+                </Stack.Navigator>
+            </NavigationContainer>
+            );
+        };
 
 const styles = StyleSheet.create({
     container: {

--- a/app/src/screens/MovementInfo.tsx
+++ b/app/src/screens/MovementInfo.tsx
@@ -25,7 +25,6 @@ const MovementInfo = ({route}:{route: any}) => {
                 resizeMode="cover"
                 source={{uri:route.params.props.data.muscleUrl}}
             />
-                {/* <Button title="Go back" onPress={() => navigation.goBack()} /> */}
         </ScrollView>
     );
 };

--- a/app/src/screens/MovementInfo.tsx
+++ b/app/src/screens/MovementInfo.tsx
@@ -1,4 +1,4 @@
-import {ScrollView, Text, StyleSheet, Button, Image} from 'react-native';
+import {ScrollView, Text, StyleSheet, View, Image, FlatList} from 'react-native';
 import React from 'react';
 import { useNavigation } from '@react-navigation/native';
 
@@ -6,6 +6,17 @@ import { useNavigation } from '@react-navigation/native';
 const MovementInfo = ({route}:{route: any}) => {
     
     const navigation = useNavigation<NativeStackNavigationProp>();
+
+    const renderImages = ({item}: {item: any}) => {
+        return (
+            <Image
+                style={styles.rectangleIcon}
+                resizeMode="cover"
+                source={{uri:item}}
+            />
+        )
+    }
+
     return (
 
         <ScrollView
@@ -14,11 +25,11 @@ const MovementInfo = ({route}:{route: any}) => {
         contentContainerStyle={styles.bodyScrollViewContent}
         >
             <Text style={styles.titleText}>{route.params.props.data.title}</Text>
-            <Image
-                style={styles.rectangleIcon}
-                resizeMode="cover"
-                source={{uri:route.params.props.data.url}}
-            />
+
+            <FlatList showsVerticalScrollIndicator={false} 
+                        data={route.params.props.data.urls} 
+                        renderItem={renderImages}/>
+
             <Text style={styles.titleText}>Muscle Map</Text>
             <Image
                 style={styles.rectangleIcon}
@@ -64,7 +75,8 @@ const styles = StyleSheet.create({
         flexShrink: 0,
         overflow: "hidden",
         borderWidth: 0.25,
-        borderColor: "#000"
+        borderColor: "#000",
+        marginBottom: 10,
     }
 });
 

--- a/app/src/screens/MovementInfo.tsx
+++ b/app/src/screens/MovementInfo.tsx
@@ -1,0 +1,72 @@
+import {ScrollView, Text, StyleSheet, Button, Image} from 'react-native';
+import React from 'react';
+import { useNavigation } from '@react-navigation/native';
+
+//This is weekly tips page
+const MovementInfo = ({route}:{route: any}) => {
+    
+    const navigation = useNavigation<NativeStackNavigationProp>();
+    return (
+
+        <ScrollView
+        style={styles.movementView}
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.bodyScrollViewContent}
+        >
+            <Text style={styles.titleText}>{route.params.props.data.title}</Text>
+            <Image
+                style={styles.rectangleIcon}
+                resizeMode="cover"
+                source={{uri:route.params.props.data.url}}
+            />
+            <Text style={styles.titleText}>Muscle Map</Text>
+            <Image
+                style={styles.rectangleIcon}
+                resizeMode="cover"
+                source={{uri:route.params.props.data.muscleUrl}}
+            />
+                {/* <Button title="Go back" onPress={() => navigation.goBack()} /> */}
+        </ScrollView>
+    );
+};
+
+const styles = StyleSheet.create({
+
+    movementView: {
+        position: "relative",
+        backgroundColor: "#D9EBF2",
+        flex: 1,
+        width: "100%",
+        height: "100%",
+        flexDirection: "column",
+    },
+    bodyScrollViewContent: {
+        alignItems: "center",
+        justifyContent: "flex-start",
+        flexDirection: "column",
+        paddingHorizontal: 10,
+        paddingVertical: 10,
+    },
+    titleText: {
+        position: "relative",
+        fontSize: 16,
+        fontWeight: "bold",
+        fontFamily: "Poppins",
+        color: "#000",
+        textAlign: "center",
+        width: 343,
+        height: 31,
+      },
+    rectangleIcon: {
+        position: "relative",
+        borderRadius: 10,
+        width: 343,
+        height: 185,
+        flexShrink: 0,
+        overflow: "hidden",
+        borderWidth: 0.25,
+        borderColor: "#000"
+    }
+});
+
+export default MovementInfo;

--- a/app/src/screens/Movements.tsx
+++ b/app/src/screens/Movements.tsx
@@ -10,8 +10,7 @@ export default class MovementScreen extends React.Component<any, any> {
         super(props);
         this.state = {
             data: {},
-            imageURLs: {},
-            muscleURL: {},
+            imgUrl:{},
         };
     }
 
@@ -26,50 +25,10 @@ export default class MovementScreen extends React.Component<any, any> {
                 }))
                 const value = doc.data()
                 if (value.imageURLs && value.imageURLs[0]) {
-                    console.log(value.imageURLs[0])
-                    const picRef = ref(storage, value.imageURLs[0])
-                    getDownloadURL(picRef)
-                        .then((url) => {
-                            this.setState((prevState: { imageURLs: any; }) => ({
-                                imageURLs: {...prevState.imageURLs, [doc.id]: url},
-                            }))
-                        })
-                        .catch((error) => {
-                            switch (error.code) {
-                                case 'storage/object-not-found':
-                                    break;
-                                case 'storage/unauthorized':
-                                    break;
-                                case 'storage/canceled':
-                                    break;
-                                case 'storage/unknown':
-                                    break;
-                            }
-                        });
+                    this.setState((prevState: { imgUrl: any; }) => ({
+                        imgUrl: {...prevState.imgUrl, [doc.id]: value.imageURLs[0]},
+                    }))
                 }
-                if (value.muscleMap) {
-                    console.log(value.muscleMap)
-                    const picRef = ref(storage, value.muscleMap)
-                    getDownloadURL(picRef)
-                        .then((url) => {
-                            this.setState((prevState: { muscleURL: any; }) => ({
-                                muscleURL: {...prevState.muscleURL, [doc.id]: url},
-                            }))
-                        })
-                        .catch((error) => {
-                            switch (error.code) {
-                                case 'storage/object-not-found':
-                                    break;
-                                case 'storage/unauthorized':
-                                    break;
-                                case 'storage/canceled':
-                                    break;
-                                case 'storage/unknown':
-                                    break;
-                            }
-                        });
-                }
-
             });
 
         }
@@ -81,8 +40,10 @@ export default class MovementScreen extends React.Component<any, any> {
         const items = [];
         for (const [key, value] of Object.entries(this.state.data)) {
             items.push(
-                {title : this.state.data[key].title, url : this.state.imageURLs[key], screenName : "MovementInfo", muscleUrl: this.state.muscleURL[key] }
+                {title : this.state.data[key].title, url : this.state.imgUrl[key], screenName : "MovementInfo", muscleUrl : this.state.data[key].muscleMap}
+
             );
+            console.log(this.state.imgUrl[key])
         }
         return items;
     }

--- a/app/src/screens/Movements.tsx
+++ b/app/src/screens/Movements.tsx
@@ -10,7 +10,6 @@ export default class MovementScreen extends React.Component<any, any> {
         super(props);
         this.state = {
             data: {},
-            imgUrl:{},
         };
     }
 
@@ -23,12 +22,6 @@ export default class MovementScreen extends React.Component<any, any> {
                 this.setState((prevState: { data: any; }) => ({
                     data: {...prevState.data, [doc.id]: doc.data()},
                 }))
-                const value = doc.data()
-                if (value.imageURLs && value.imageURLs[0]) {
-                    this.setState((prevState: { imgUrl: any; }) => ({
-                        imgUrl: {...prevState.imgUrl, [doc.id]: value.imageURLs[0]},
-                    }))
-                }
             });
 
         }
@@ -40,17 +33,16 @@ export default class MovementScreen extends React.Component<any, any> {
         const items = [];
         for (const [key, value] of Object.entries(this.state.data)) {
             items.push(
-                {title : this.state.data[key].title, url : this.state.imgUrl[key], screenName : "MovementInfo", muscleUrl : this.state.data[key].muscleMap}
+                {title : this.state.data[key].title, urls : this.state.data[key].imageURLs, screenName : "MovementInfo", muscleUrl : this.state.data[key].muscleMap}
 
             );
-            console.log(this.state.imgUrl[key])
         }
         return items;
     }
 
     renderCard = ({item}: {item: any}) => {
         return (
-          <ExerciseCard screenName={item.screenName} imageAddr={item.url} name={item.title} data={item} />
+          <ExerciseCard screenName={item.screenName} imageAddr={item.urls[0]} name={item.title} data={item} />
         )
     }
 

--- a/app/src/screens/Movements.tsx
+++ b/app/src/screens/Movements.tsx
@@ -11,6 +11,7 @@ export default class MovementScreen extends React.Component<any, any> {
         this.state = {
             data: {},
             imageURLs: {},
+            muscleURL: {},
         };
     }
 
@@ -46,6 +47,29 @@ export default class MovementScreen extends React.Component<any, any> {
                             }
                         });
                 }
+                if (value.muscleMap) {
+                    console.log(value.muscleMap)
+                    const picRef = ref(storage, value.muscleMap)
+                    getDownloadURL(picRef)
+                        .then((url) => {
+                            this.setState((prevState: { muscleURL: any; }) => ({
+                                muscleURL: {...prevState.muscleURL, [doc.id]: url},
+                            }))
+                        })
+                        .catch((error) => {
+                            switch (error.code) {
+                                case 'storage/object-not-found':
+                                    break;
+                                case 'storage/unauthorized':
+                                    break;
+                                case 'storage/canceled':
+                                    break;
+                                case 'storage/unknown':
+                                    break;
+                            }
+                        });
+                }
+
             });
 
         }
@@ -57,7 +81,7 @@ export default class MovementScreen extends React.Component<any, any> {
         const items = [];
         for (const [key, value] of Object.entries(this.state.data)) {
             items.push(
-                {title : this.state.data[key].title, url : this.state.imageURLs[key], screenName : "MovementInfo"}
+                {title : this.state.data[key].title, url : this.state.imageURLs[key], screenName : "MovementInfo", muscleUrl: this.state.muscleURL[key] }
             );
         }
         return items;
@@ -65,7 +89,7 @@ export default class MovementScreen extends React.Component<any, any> {
 
     renderCard = ({item}: {item: any}) => {
         return (
-          <ExerciseCard screenName={item.screenName} imageAddr={item.url} name={item.title} />
+          <ExerciseCard screenName={item.screenName} imageAddr={item.url} name={item.title} data={item} />
         )
     }
 


### PR DESCRIPTION
Add changes to navigate from each movement to the info page to show related images and muscle map for that move.
<img width="398" alt="Screen Shot 2022-11-26 at 12 48 52 PM" src="https://user-images.githubusercontent.com/23587493/204108525-e998780e-0759-4276-b89a-611a78dbd747.png">
<img width="395" alt="Screen Shot 2022-11-26 at 12 49 11 PM" src="https://user-images.githubusercontent.com/23587493/204108541-b86854e4-81d8-4259-845f-7e13fb6f8fc1.png">
<img width="399" alt="Screen Shot 2022-11-26 at 12 49 26 PM" src="https://user-images.githubusercontent.com/23587493/204108561-71b4bbbd-d0c5-4101-90ed-2da8a6676c73.png"> 
<img width="396" alt="Screen Shot 2022-11-26 at 12 49 43 PM" src="https://user-images.githubusercontent.com/23587493/204108569-f9421bdc-d142-4496-9e1b-d66e5253bc78.png">
 
